### PR TITLE
feat(state): React Query, кэширование, хуки (#18)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^13.5.0",
+    "@tanstack/react-query": "^5.62.0",
     "axios": "^1.13.6",
     "clsx": "^2.1.1",
     "react": "^19.2.4",

--- a/frontend/src/app/App.jsx
+++ b/frontend/src/app/App.jsx
@@ -1,9 +1,23 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from "./providers/router";
 
 import "./styles/global.css";
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      retry: 1,
+    },
+  },
+});
+
 function App() {
-  return <RouterProvider />;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider />
+    </QueryClientProvider>
+  );
 }
 
 export default App;

--- a/frontend/src/entities/object/api/objectQueries.js
+++ b/frontend/src/entities/object/api/objectQueries.js
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { getObjects, getObjectById } from 'shared/api/benuaApi';
+
+export const objectKeys = {
+  all: ['objects'],
+  detail: (id) => ['objects', id],
+};
+
+export const useObjects = () =>
+  useQuery({
+    queryKey: objectKeys.all,
+    queryFn: getObjects,
+  });
+
+export const useObjectById = (id) =>
+  useQuery({
+    queryKey: objectKeys.detail(id),
+    queryFn: () => getObjectById(id),
+    enabled: !!id,
+  });

--- a/frontend/src/entities/person/api/personQueries.js
+++ b/frontend/src/entities/person/api/personQueries.js
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { getPersons, getPersonById } from 'shared/api/benuaApi';
+
+export const personKeys = {
+  all: ['persons'],
+  detail: (id) => ['persons', id],
+};
+
+export const usePersons = () =>
+  useQuery({
+    queryKey: personKeys.all,
+    queryFn: getPersons,
+  });
+
+export const usePersonById = (id) =>
+  useQuery({
+    queryKey: personKeys.detail(id),
+    queryFn: () => getPersonById(id),
+    enabled: !!id,
+  });


### PR DESCRIPTION
Closes #18

Установлен `@tanstack/react-query`. Настроен `QueryClient` с `staleTime: 5min`. Добавлены хуки `usePersons`, `usePersonById`, `useObjects`, `useObjectById`.