### PR TITLE
feat: add object and person cards, page layout

### DIFF
--- a/frontend/src/entities/objects/index.js
+++ b/frontend/src/entities/objects/index.js
@@ -1,0 +1,2 @@
+export { ObjectCard } from './ui/ObjectCard';
+export {objects, getObjects, getObjectById, getObjectsByCategory} from './model/object';

--- a/frontend/src/entities/objects/model/object.js
+++ b/frontend/src/entities/objects/model/object.js
@@ -1,0 +1,37 @@
+export const objects = [
+  {
+    id: 1,
+    title: 'Здание государственного дворянского земельного банка',
+    address: 'Адмиралтейская наб., 12-14',
+    authors: 'Бенуа Л.Н., Кракау А.И., Иванов А.И.',
+    category: 'Общественные и административные здания',
+    subcategory: 'банки',
+    image: null
+  },
+  {
+    id: 2,
+    title: 'Русский для внешней торговли банк',
+    address: 'Большая Морская ул., 18',
+    authors: 'Бенуа Л.Н., Лидваль Ф.И., Рулен Л.В.',
+    category: 'Общественные и административные здания',
+    subcategory: 'страховые',
+    image: null
+  },
+  {
+    id: 3,
+    title: 'Здание первого российского страхового общества',
+    address: 'Большая Морская ул., 40',
+    authors: 'Бенуа Л.Н., Бенуа Ю.Ю.',
+    category: 'Общественные и административные здания',
+    subcategory: 'банки',
+    image: null
+  }
+];
+
+export const getObjects = () => objects;
+
+export const getObjectById = (id) =>
+  objects.find(object => object.id === id);
+
+export const getObjectsByCategory = (category) =>
+  objects.filter(object => object.category === category);

--- a/frontend/src/entities/objects/styles/ObjectCard.module.css
+++ b/frontend/src/entities/objects/styles/ObjectCard.module.css
@@ -1,0 +1,111 @@
+.card {
+    background: var(--darker-beige);
+    overflow: hidden;
+    transition: transform 1s ease;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
+    cursor: pointer;
+}
+
+.card:hover {
+    background-color: var(--dark-red);
+}
+
+.imageWrapper {
+    position: relative;
+    height: 400px;
+    overflow: hidden;
+    padding-bottom: 0;
+}
+
+.testphoto {
+    width: 100%;
+    height: 100%;
+    background-color: #666;
+}
+
+.image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s ease;
+}
+
+.card:hover .image {
+    transform: scale(1.05);
+}
+
+.content {
+    padding-top: 10px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.title {
+    font-family: var(--font-lora);
+    font-size: 0.875rem;
+    font-weight: 300;
+    line-height: 1.5;
+    margin: 0 0 0 0;
+    color: var(--black);
+}
+
+.card:hover .title {
+    color: var(--beige);
+}
+
+.description {
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    align-content: flex-start;
+    margin-top: 0;
+}
+
+.label {
+    background: transparent;
+    opacity: 50%;
+    color: var(--grey-stroke);
+    padding-top: 5px;
+    font-size: 1rem;
+    font-weight: 400;
+    width: fit-content;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.card:hover .label {
+    border-color: var(--beige);
+    color: var(--beige);
+    opacity: 70%;
+}
+
+@media (max-width: 768px) {
+    .imageWrapper {
+        height: 180px;
+    }
+
+    .content {
+        padding: 16px;
+    }
+
+    .title {
+        font-size: 1.1rem;
+    }
+
+    .description {
+        font-size: 0.85rem;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
+    }
+
+    .price {
+        font-size: 1.1rem;
+    }
+}

--- a/frontend/src/entities/objects/ui/ObjectCard.jsx
+++ b/frontend/src/entities/objects/ui/ObjectCard.jsx
@@ -1,0 +1,43 @@
+import { useNavigate } from 'react-router-dom';
+import styles from '../styles/ObjectCard.module.css';
+
+export function ObjectCard({ object }) {
+  const navigate = useNavigate();
+
+  const handleCardClick = () => {
+    navigate(`/objects/${object.id}`);
+  };
+
+  return (
+    <article className={styles.card} onClick={handleCardClick}>
+      <div className={styles.imageWrapper}>
+        {object.image ? (
+          <img
+            src={object.image}
+            alt={object.title}
+            className={styles.image}
+            loading="lazy"
+          />
+        ) : (
+          <div className={styles.testphoto} />
+        )}
+      </div>
+
+      <div className={styles.content}>
+        <h3 className={styles.title}>
+          {object.title.toUpperCase()}
+        </h3>
+
+        <div className={styles.description}>
+          <span className={styles.label}>
+            {object.address}
+          </span>
+
+          <span className={styles.label}>
+            {object.authors}
+          </span>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/entities/persons/index.js
+++ b/frontend/src/entities/persons/index.js
@@ -1,0 +1,2 @@
+export { PersonCard } from './ui/PersonCard';
+export {persons, getPersons, getPersonById} from './model/person';

--- a/frontend/src/entities/persons/model/person.js
+++ b/frontend/src/entities/persons/model/person.js
@@ -1,0 +1,31 @@
+export const persons = [
+  {
+    id: 1,
+    name: 'Леонтий Бенуа',
+    description: 'Известный архитектор, представитель династии Бенуа',
+    image: null
+  },
+  {
+    id: 2,
+    name: 'Александр Бенуа',
+    description: 'Художник, историк искусства, основатель "Мира искусства"',
+    image: null
+  },
+  {
+    id: 3,
+    name: 'Николай Бенуа',
+    description: 'Архитектор, академик архитектуры',
+    image: null
+  },
+  {
+    id: 4,
+    name: 'TEST',
+    description: 'test1, test2, test3, test4',
+    image: null
+  }
+];
+
+export const getPersons = () => persons;
+
+export const getPersonById = (id) =>
+  persons.find(person => person.id === id);

--- a/frontend/src/entities/persons/styles/PersonCard.module.css
+++ b/frontend/src/entities/persons/styles/PersonCard.module.css
@@ -1,0 +1,111 @@
+.card {
+    background: var(--darker-beige);
+    overflow: hidden;
+    transition: transform 1s ease;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
+    cursor: pointer;
+}
+
+.card:hover {
+    background-color: var(--dark-red);
+}
+
+.imageWrapper {
+    position: relative;
+    height: 400px;
+    overflow: hidden;
+    padding-bottom: 0;
+}
+
+.testphoto {
+    width: 100%;
+    height: 100%;
+    background-color: #666;
+}
+
+.image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s ease;
+}
+
+.card:hover .image {
+    transform: scale(1.05);
+}
+
+.content {
+    padding-top: 10px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.title {
+    font-family: var(--font-lora);
+    font-size: 0.875rem;
+    font-weight: 300;
+    line-height: 1.5;
+    margin: 0 0 0 0;
+    color: var(--black);
+}
+
+.card:hover .title {
+    color: var(--beige);
+}
+
+.description {
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    align-content: flex-start;
+    margin-top: 0;
+}
+
+.label {
+    background: transparent;
+    opacity: 50%;
+    color: var(--grey-stroke);
+    padding-top: 5px;
+    font-size: 1rem;
+    font-weight: 400;
+    width: fit-content;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.card:hover .label {
+    border-color: var(--beige);
+    color: var(--beige);
+    opacity: 70%;
+}
+
+@media (max-width: 768px) {
+    .imageWrapper {
+        height: 180px;
+    }
+
+    .content {
+        padding: 16px;
+    }
+
+    .title {
+        font-size: 1.1rem;
+    }
+
+    .description {
+        font-size: 0.85rem;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
+    }
+
+    .price {
+        font-size: 1.1rem;
+    }
+}

--- a/frontend/src/entities/persons/ui/PersonCard.jsx
+++ b/frontend/src/entities/persons/ui/PersonCard.jsx
@@ -1,0 +1,36 @@
+import { useNavigate } from 'react-router-dom';
+import styles from '../styles/PersonCard.module.css';
+
+export function PersonCard({ person }) {
+  const navigate = useNavigate();
+
+  const handleCardClick = () => {
+    navigate(`/persons/${person.id}`);
+  };
+
+  return (
+    <article className={styles.card} onClick={handleCardClick}>
+      <div className={styles.imageWrapper}>
+        {person.image ? (
+          <img
+            src={person.image}
+            alt={person.name}
+            className={styles.image}
+          />
+        ) : (
+          <div className={styles.testphoto} />
+        )}
+      </div>
+
+      <div className={styles.content}>
+        <h3 className={styles.title}>{person.name.toUpperCase()}</h3>
+
+        <div className={styles.description}>
+          <span className={styles.label}>
+            {person.description}
+          </span>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/pages/home/ui/components/MapInfo/MapInfo.module.css
+++ b/frontend/src/pages/home/ui/components/MapInfo/MapInfo.module.css
@@ -82,3 +82,60 @@
     border-radius: 8px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
+
+@media (max-width: 768px) {
+
+  .mapInfo {
+    flex-direction: column; /* ← КЛЮЧ */
+    gap: 2rem;
+    padding: 2rem 10px;
+  }
+
+  .mapInfoInnerContainer {
+    flex-direction: column; /* ← КЛЮЧ */
+    gap: 1rem;
+  }
+
+  .mapInfoRightColumn p {
+    text-indent: 0; /* ← убираем отступ */
+  }
+
+  .mapPictureContainer {
+    min-height: auto;
+    width: 100%;
+  }
+
+  .mapPictureContainer img {
+    width: 100%; /* ← КЛЮЧ */
+    height: auto;
+  }
+
+}
+
+@media (max-width: 1090px) {
+
+  .mapInfo {
+    flex-direction: column; /* ← как mobile */
+    gap: 2rem;
+    padding: 3rem 20px;
+  }
+
+  .mapInfoInnerContainer {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .mapInfoRightColumn p {
+    text-indent: 0;
+  }
+
+  .mapPictureContainer {
+    width: 100%;
+  }
+
+  .mapPictureContainer img {
+    width: 100%;
+    height: auto;
+  }
+
+}

--- a/frontend/src/pages/objects/index.js
+++ b/frontend/src/pages/objects/index.js
@@ -1,1 +1,1 @@
-export { Objects } from "./ui/Objects";
+export { Objects } from './ui/Objects';

--- a/frontend/src/pages/objects/ui/Objects.jsx
+++ b/frontend/src/pages/objects/ui/Objects.jsx
@@ -1,8 +1,63 @@
-export const Objects = () => {
+import { useState } from "react";
+import { ObjectList } from "widgets/object-list";
+import { getObjects } from "entities/objects";
+import styles from "widgets/object-list/styles/ObjectList.module.css"
+
+export function Objects() {
+  const [category, setCategory] = useState('Общественные и административные здания');
+  const [open, setOpen] = useState(false);
+
+  const objects = getObjects();
+
+  const categories = [
+    'Общественные и административные здания',
+    'Культурные и исторические объекты',
+    'Религиозные сооружения',
+    'Жилые и доходные дома',
+    'Учебные заведения',
+    'Промышленные и транспортные объекты',
+    'Дачи (загородные объекты)'
+  ];
+
   return (
-    <div style={{ padding: "2rem", textAlign: "center" }}>
-      <h1>Объекты</h1>
-      <p>Здесь будет контент главной страницы</p>
+    <div className="page">
+      <div className="header">
+        <h1 className="title">Объекты</h1>
+        <div className={styles.undertitle}>Выбрать категорию:</div>
+      </div>
+
+      <div className={styles.dropdown}>
+        <div
+          className={styles.dropdownHeader}
+          onClick={() => setOpen(!open)}
+        >
+          {category}
+          <span className={styles.arrow}></span>
+        </div>
+
+          <div
+            className={`${styles.dropdownList} ${
+              open ? styles.open : ''
+            }`}
+          >
+            {categories.map(cat => (
+              <div
+                key={cat}
+                className={styles.dropdownItem}
+                onClick={() => {
+                  setCategory(cat);
+                  setOpen(false);
+                }}
+              >
+                {cat}
+              </div>
+            ))}
+          </div>
+
+      </div>
+
+      <ObjectList objects={objects} selectedCategory={category}/>
+
     </div>
   );
-};
+}

--- a/frontend/src/pages/persons/ui/Persons.jsx
+++ b/frontend/src/pages/persons/ui/Persons.jsx
@@ -1,8 +1,17 @@
-export const Persons = () => {
+import { useState } from "react";
+import { PersonList } from "widgets/person-list";
+import { getPersons } from "entities/persons";
+
+export function Persons() {
+  const [persons] = useState(getPersons());
+
   return (
-    <div style={{ padding: "2rem", textAlign: "center" }}>
-      <h1>Персоналии</h1>
-      <p>Здесь будет контент главной страницы</p>
+    <div className="page">
+      <div className="header">
+        <h1 className="title">Персоналии</h1>
+      </div>
+
+      <PersonList persons={persons} />
     </div>
   );
 };

--- a/frontend/src/widgets/footer/ui/Footer.module.css
+++ b/frontend/src/widgets/footer/ui/Footer.module.css
@@ -112,3 +112,68 @@
     margin: 0;
     padding-top: 0.5rem;
   }
+
+  @media (max-width: 768px) {
+  .container {
+    padding: 20px 10px;
+    box-sizing: border-box;
+  }
+
+  .footerContent {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .leftColumn {
+    align-items: center;
+  }
+
+  .centerColumns {
+    grid-template-columns: 1fr;
+    padding: 0;
+    gap: 1rem;
+  }
+
+  .rightColumn {
+    align-items: center;
+  }
+
+  .BenuaLogo {
+    height: 120px;
+  }
+
+  .socialIconsContainer {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 1090px) {
+  .container {
+    padding: 20px;
+    box-sizing: border-box;
+  }
+
+  .footerContent {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .leftColumn {
+    align-items: center;
+  }
+
+  .centerColumns {
+    grid-template-columns: 1fr;
+    padding: 0;
+    gap: 1rem;
+  }
+
+  .rightColumn {
+    align-items: center;
+    margin-top: 20px;
+  }
+
+  .socialIconsContainer {
+    justify-content: center;
+  }
+}

--- a/frontend/src/widgets/header/ui/Header.module.css
+++ b/frontend/src/widgets/header/ui/Header.module.css
@@ -2,7 +2,7 @@
     position: fixed;
     top: 0;
     z-index: 1000;
-    width: 100vw;
+    width: 100%;
     padding: 0;
     justify-content: center;
     backdrop-filter: blur(10px);
@@ -10,7 +10,7 @@
 }
 
 .navbarContainer {
-    max-width: 100vw;
+    max-width: 100%;
     display: grid;
     grid-template-columns: 10vw 1fr 10vw;
     align-items: center;
@@ -163,4 +163,47 @@
     height: 35px;
     background-color: var(--dark-blue);
     color: white;
+}
+
+@media (max-width: 768px) {
+  .navbarContainer {
+    grid-template-columns: auto 1fr;
+    padding-left: 10px;
+    padding-right: 10px;
+    box-sizing: border-box;
+  }
+
+  .navList {
+    margin: 0;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .navLink {
+    font-size: 14px;
+    padding: 8px 10px;
+  }
+
+  .searchContainer {
+    width: 100%;
+    max-width: 150px;
+    grid-column: 1 / -1;
+  }
+
+  .searchWrapper.searchOpen {
+    width: 100%;
+    max-width: 150px;
+  }
+
+  .searchWrapper {
+    overflow: visible;
+  }
+
+  body {
+    padding-top: 30px;
+  }
+
+  .navbarContainer {
+    padding-bottom: 10px;
+  }
 }

--- a/frontend/src/widgets/object-list/index.js
+++ b/frontend/src/widgets/object-list/index.js
@@ -1,0 +1,1 @@
+export { ObjectList } from './ui/ObjectList';

--- a/frontend/src/widgets/object-list/styles/ObjectList.module.css
+++ b/frontend/src/widgets/object-list/styles/ObjectList.module.css
@@ -1,0 +1,95 @@
+.grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    padding: 0 var(--page-padding);
+    row-gap: 40px;
+    margin-bottom: var(--page-padding);
+}
+
+@media (max-width: 1024px) {
+    .grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 20px;
+        row-gap: 40px;
+    }
+}
+
+@media (max-width: 768px) {
+    .grid {
+        grid-template-columns: 1fr;
+        gap: 20px;
+    }
+}
+
+.section {
+    margin-bottom: 40px;
+}
+
+.subtitle {
+    font-size: 18px;
+    font-weight: 600;
+    margin: 0 var(--page-padding) 15px;
+    text-transform: capitalize;
+}
+
+
+.dropdown {
+  width: 100%;
+  max-width: 600px;
+  margin: 20px auto;
+  border-radius: 20px;
+  border: 1px solid #0b2a5b;
+  overflow: hidden;
+}
+
+.dropdownHeader {
+  background: #0b2a5b;
+  color: white;
+  padding: 15px 20px;
+  font-size: 18px;
+  cursor: pointer;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.dropdownList {
+  background: var(--beige);
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 1s ease, opacity 1s ease;
+}
+
+.open {
+  max-height: 500px;
+  opacity: 1;
+}
+
+.dropdownItem {
+  padding: 12px 20px;
+  text-align: center;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.dropdownItem:hover {
+  background: rgba(0,0,0,0.05);
+  transform: scale(1.05);
+}
+
+.dropdownHeader:not(.openHeader):hover {
+  transform: scale(1.05);
+}
+
+.undertitle {
+  position: relative;
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  font-family: var(--font-lora);
+  font-size: 1.7rem;
+  color: black;
+}

--- a/frontend/src/widgets/object-list/ui/ObjectList.jsx
+++ b/frontend/src/widgets/object-list/ui/ObjectList.jsx
@@ -1,0 +1,33 @@
+import styles from '../styles/ObjectList.module.css';
+import { ObjectCard } from 'entities/objects';
+
+export function ObjectList({ objects, selectedCategory }) {
+  const filtered = objects.filter(
+    obj => obj.category === selectedCategory
+  );
+
+  // группировка по подкатегориям
+  const grouped = filtered.reduce((acc, obj) => {
+    if (!acc[obj.subcategory]) {
+      acc[obj.subcategory] = [];
+    }
+    acc[obj.subcategory].push(obj);
+    return acc;
+  }, {});
+
+  return (
+    <div>
+      {Object.entries(grouped).map(([subcategory, items]) => (
+        <div key={subcategory} className={styles.section}>
+          <h2 className={styles.subtitle}>{subcategory}</h2>
+
+          <div className={styles.grid}>
+            {items.map(object => (
+              <ObjectCard key={object.id} object={object} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/widgets/person-list/index.js
+++ b/frontend/src/widgets/person-list/index.js
@@ -1,0 +1,1 @@
+export { PersonList } from './ui/PersonList';

--- a/frontend/src/widgets/person-list/styles/PersonList.module.css
+++ b/frontend/src/widgets/person-list/styles/PersonList.module.css
@@ -1,0 +1,23 @@
+.grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    padding: 0 var(--page-padding);
+    row-gap: 40px;
+    margin-bottom: var(--page-padding);
+}
+
+@media (max-width: 1024px) {
+    .grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 20px;
+        row-gap: 40px;
+    }
+}
+
+@media (max-width: 768px) {
+    .grid {
+        grid-template-columns: 1fr;
+        gap: 20px;;
+    }
+}

--- a/frontend/src/widgets/person-list/ui/PersonList.jsx
+++ b/frontend/src/widgets/person-list/ui/PersonList.jsx
@@ -1,0 +1,15 @@
+import { PersonCard } from 'entities/persons';
+import styles from '../styles/PersonList.module.css';
+
+export function PersonList({ persons }) {
+  return (
+    <div className={styles.grid}>
+      {persons.map(person => (
+        <PersonCard
+          key={person.id}
+          person={person}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Что сделано

- Реализованы страницы `/persons` и `/objects`
- Реализованы компоненты `PersonCard`, `ObjectCard` — карточки с изображением, названием и описанием
- Добавлено меню разбивки по категориям через выпадающее меню на странице `/objects`
- Настроена адаптивная верстка под mobile / tablet / desktop

## Детали

- Карточки:
  -`ObjectCard`: id, заголовок, адрес, авторы, категория, подкатегория, изображение
  -`PersonCard`: id, имя, описание, изображение
- Сетка автоматически адаптируется под размер экрана
- Меню позволяет выбирать категорию
- Меню анимировано