### PR TITLE
feat(s3): drag-and-drop image uploader в формах редактирования объектов и персон

### DIFF
--- a/backend/src/main/java/com/benua/backend/dto/BuildingCreateDto.java
+++ b/backend/src/main/java/com/benua/backend/dto/BuildingCreateDto.java
@@ -22,6 +22,7 @@ public record BuildingCreateDto(
         @JsonProperty("connected_objects") List<String> connectedObjects,
         @JsonProperty("sources") List<SourceCreateDto> sources,
         @JsonProperty("images") List<ImageCreateDto> images,
+        @JsonProperty("image_ids") List<String> imageIds,
         @JsonProperty("building_type") String buildingType,
         @JsonProperty("building_subtype") String buildingSubtype
 ) {}

--- a/backend/src/main/java/com/benua/backend/dto/PersonCreateDto.java
+++ b/backend/src/main/java/com/benua/backend/dto/PersonCreateDto.java
@@ -17,5 +17,6 @@ public record PersonCreateDto(
         @JsonProperty("connected_persons") List<String> connectedPersons,
         @JsonProperty("connected_objects") List<String> connectedObjects,
         @JsonProperty("images") List<ImageCreateDto> images,
+        @JsonProperty("image_ids") List<String> imageIds,
         @JsonProperty("sources") List<SourceCreateDto> sources
 ) {}

--- a/backend/src/main/java/com/benua/backend/service/BuildingService.java
+++ b/backend/src/main/java/com/benua/backend/service/BuildingService.java
@@ -87,7 +87,10 @@ public class BuildingService {
     public BuildingDto createBuilding(BuildingCreateDto building, String updatedBy) {
         List<String> connectedPeople = building.connectedPersons() != null ? building.connectedPersons() : List.of();
         List<String> connectedBuildings = building.connectedObjects() != null ? building.connectedObjects() : List.of();
-        List<Image> images = cs.saveImages(building.images());
+        // Prefer pre-uploaded imageIds (from /admin/images); fall back to inline ImageCreateDto
+        List<Image> images = (building.imageIds() != null && !building.imageIds().isEmpty())
+                ? cs.getImagesByIds(building.imageIds())
+                : cs.saveImages(building.images());
         List<Source> sources = cs.saveSources(building.sources());
 
         Building newBuilding = new Building(

--- a/backend/src/main/java/com/benua/backend/service/ConnectionService.java
+++ b/backend/src/main/java/com/benua/backend/service/ConnectionService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * Логика для устранения циклической связи BuildingService <-> PersonService в create

--- a/backend/src/main/java/com/benua/backend/service/PersonService.java
+++ b/backend/src/main/java/com/benua/backend/service/PersonService.java
@@ -87,7 +87,10 @@ public class PersonService {
     public PersonDto createPerson(PersonCreateDto person, String updatedBy) {
         List<String> connectedPeople = person.connectedPersons() != null ? person.connectedPersons() : List.of();
         List<String> connectedBuildings = person.connectedObjects() != null ? person.connectedObjects() : List.of();
-        List<Image> images = cs.saveImages(person.images());
+        // Prefer pre-uploaded imageIds (from /admin/images); fall back to inline ImageCreateDto
+        List<Image> images = (person.imageIds() != null && !person.imageIds().isEmpty())
+                ? cs.getImagesByIds(person.imageIds())
+                : cs.saveImages(person.images());
         List<Source> sources = cs.saveSources(person.sources());
 
         Person newPerson = new Person(

--- a/frontend-admin/src/entities/building/types.ts
+++ b/frontend-admin/src/entities/building/types.ts
@@ -43,6 +43,7 @@ export interface BuildingCreateDto {
   connected_persons?: string[];
   connected_objects?: string[];
   images?: InlineImage[];
+  image_ids?: string[];
 }
 
 export interface BuildingUpdateDto {

--- a/frontend-admin/src/entities/person/types.ts
+++ b/frontend-admin/src/entities/person/types.ts
@@ -44,6 +44,7 @@ export interface PersonCreateDto {
   connected_persons?: string[];
   connected_objects?: string[];
   images?: InlineImage[];
+  image_ids?: string[];
 }
 
 export interface PersonUpdateDto {

--- a/frontend-admin/src/features/image-uploader/ImageUploader.tsx
+++ b/frontend-admin/src/features/image-uploader/ImageUploader.tsx
@@ -1,8 +1,10 @@
 import { Upload, Modal, message } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
+import { InboxOutlined } from '@ant-design/icons';
 import type { UploadFile, UploadProps } from 'antd';
 import { imageApi } from 'entities/image/api';
 import type { ImageDto } from 'entities/image/types';
+
+const { Dragger } = Upload;
 
 interface Props {
   value?: ImageDto[];
@@ -16,11 +18,19 @@ export function ImageUploader({ value = [], onChange, maxCount }: Props) {
     name: img.text || img._id,
     status: 'done' as const,
     url: img.url_to_s3,
+    thumbUrl: img.url_to_s3,
   }));
 
-  const handleUpload: UploadProps['customRequest'] = async ({ file, onSuccess, onError }) => {
+  const handleUpload: UploadProps['customRequest'] = async ({
+    file,
+    onSuccess,
+    onError,
+    onProgress,
+  }) => {
     try {
+      onProgress?.({ percent: 20 });
       const uploaded = await imageApi.upload(file as File);
+      onProgress?.({ percent: 100 });
       onChange?.([...value, uploaded]);
       onSuccess?.(uploaded);
     } catch (err) {
@@ -33,6 +43,7 @@ export function ImageUploader({ value = [], onChange, maxCount }: Props) {
     new Promise((resolve) => {
       Modal.confirm({
         title: 'Удалить фото?',
+        content: 'Файл будет удалён из хранилища. Это действие необратимо.',
         okText: 'Удалить',
         okButtonProps: { danger: true },
         cancelText: 'Отмена',
@@ -50,21 +61,29 @@ export function ImageUploader({ value = [], onChange, maxCount }: Props) {
       });
     });
 
+  const atLimit = !!maxCount && fileList.length >= maxCount;
+
   return (
-    <Upload
-      listType="picture-card"
+    <Dragger
+      listType="picture"
       fileList={fileList}
       customRequest={handleUpload}
       onRemove={handleRemove}
       accept="image/jpeg,image/png,image/webp"
-      maxCount={maxCount}
+      multiple={!maxCount || maxCount > 1}
+      disabled={atLimit}
+      style={atLimit ? { pointerEvents: 'none', opacity: 0.5 } : undefined}
     >
-      {(!maxCount || fileList.length < maxCount) && (
-        <div>
-          <PlusOutlined />
-          <div style={{ marginTop: 8 }}>Загрузить</div>
-        </div>
-      )}
-    </Upload>
+      <p className="ant-upload-drag-icon">
+        <InboxOutlined />
+      </p>
+      <p className="ant-upload-text">
+        Перетащите изображения сюда или нажмите для выбора
+      </p>
+      <p className="ant-upload-hint">
+        JPG, PNG, WebP · не более 10 МБ на файл
+        {maxCount ? ` · максимум ${maxCount} шт.` : ''}
+      </p>
+    </Dragger>
   );
 }

--- a/frontend-admin/src/pages/buildings/BuildingEditPage.tsx
+++ b/frontend-admin/src/pages/buildings/BuildingEditPage.tsx
@@ -4,7 +4,9 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useBuilding, useCreateBuilding, useUpdateBuilding } from 'entities/building/queries';
 import { AjaxSelect } from 'features/ajax-select/AjaxSelect';
 import { RichTextEditor } from 'features/rich-text/RichTextEditor';
+import { ImageUploader } from 'features/image-uploader/ImageUploader';
 import type { BuildingCreateDto, BuildingUpdateDto } from 'entities/building/types';
+import type { ImageDto } from 'entities/image/types';
 import { ROUTES } from 'shared/config/routes';
 
 const BUILDING_CATEGORIES = [
@@ -104,10 +106,13 @@ export function BuildingEditPage({ mode }: Props) {
           is_published: existing.is_published ?? false,
           connected_persons: existing.connected_persons?.map((p) => p._id) ?? [],
           connected_objects: existing.connected_objects?.map((o) => o._id) ?? [],
+          images: existing.images ?? [],
         }
-      : { is_published: false, description: [], interesting_facts: [] };
+      : { is_published: false, description: [], interesting_facts: [], images: [] };
 
   const onFinish = async (values: Record<string, unknown>) => {
+    const uploadedImages = (values.images as ImageDto[] | undefined) ?? [];
+    const imageIds = uploadedImages.map((img) => img._id);
     try {
       if (mode === 'create') {
         const dto: BuildingCreateDto = {
@@ -125,6 +130,7 @@ export function BuildingEditPage({ mode }: Props) {
           is_published: values.is_published as boolean,
           connected_persons: values.connected_persons as string[] | undefined,
           connected_objects: values.connected_objects as string[] | undefined,
+          image_ids: imageIds,
         };
         await createMutation.mutateAsync(dto);
         message.success('Объект создан');
@@ -144,7 +150,7 @@ export function BuildingEditPage({ mode }: Props) {
           is_published: values.is_published as boolean,
           connected_persons: values.connected_persons as string[] | undefined,
           connected_objects: values.connected_objects as string[] | undefined,
-          image_ids: (existing?.images ?? []).map((img) => img._id),
+          image_ids: imageIds,
         };
         await updateMutation.mutateAsync(dto);
         message.success('Объект обновлён');
@@ -255,6 +261,11 @@ export function BuildingEditPage({ mode }: Props) {
               )
             }
           />
+        </Form.Item>
+
+        <Divider>Фотографии</Divider>
+        <Form.Item name="images">
+          <ImageUploader />
         </Form.Item>
 
         <Divider />

--- a/frontend-admin/src/pages/persons/PersonEditPage.tsx
+++ b/frontend-admin/src/pages/persons/PersonEditPage.tsx
@@ -4,7 +4,9 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { usePerson, useCreatePerson, useUpdatePerson } from 'entities/person/queries';
 import { AjaxSelect } from 'features/ajax-select/AjaxSelect';
 import { RichTextEditor } from 'features/rich-text/RichTextEditor';
+import { ImageUploader } from 'features/image-uploader/ImageUploader';
 import type { PersonCreateDto, PersonUpdateDto } from 'entities/person/types';
+import type { ImageDto } from 'entities/image/types';
 import { ROUTES } from 'shared/config/routes';
 
 interface Props {
@@ -37,10 +39,13 @@ export function PersonEditPage({ mode }: Props) {
           is_published: existing.is_published ?? false,
           connected_persons: existing.connected_persons?.map((p) => p._id) ?? [],
           connected_objects: existing.connected_objects?.map((o) => o._id) ?? [],
+          images: existing.images ?? [],
         }
-      : { is_published: false, description: [], interesting_facts: [] };
+      : { is_published: false, description: [], interesting_facts: [], images: [] };
 
   const onFinish = async (values: Record<string, unknown>) => {
+    const uploadedImages = (values.images as ImageDto[] | undefined) ?? [];
+    const imageIds = uploadedImages.map((img) => img._id);
     try {
       if (mode === 'create') {
         const dto: PersonCreateDto = {
@@ -53,6 +58,7 @@ export function PersonEditPage({ mode }: Props) {
           interesting_facts: values.interesting_facts as string[] | undefined,
           connected_persons: values.connected_persons as string[] | undefined,
           connected_objects: values.connected_objects as string[] | undefined,
+          image_ids: imageIds,
         };
         await createMutation.mutateAsync(dto);
         message.success('Персона создана');
@@ -68,7 +74,7 @@ export function PersonEditPage({ mode }: Props) {
           is_published: values.is_published as boolean,
           connected_persons: values.connected_persons as string[] | undefined,
           connected_objects: values.connected_objects as string[] | undefined,
-          image_ids: (existing?.images ?? []).map((img) => img._id),
+          image_ids: imageIds,
         };
         await updateMutation.mutateAsync(dto);
         message.success('Персона обновлена');
@@ -152,6 +158,11 @@ export function PersonEditPage({ mode }: Props) {
             </>
           )}
         </Form.List>
+
+        <Divider>Фотографии</Divider>
+        <Form.Item name="images">
+          <ImageUploader />
+        </Form.Item>
 
         <Divider />
         <Form.Item name="is_published" label="Опубликовано" valuePropName="checked">


### PR DESCRIPTION
## Что сделано

Добавлен drag & drop загрузчик изображений в формы редактирования **объектов** (Buildings) и **персон** (Persons) в админ-панели. Фотографии загружаются напрямую в Yandex S3, ссылки сохраняются в MongoDB.

## Изменения

### Бэкенд
- `BuildingCreateDto` / `PersonCreateDto` — добавлено поле `image_ids` для передачи ID предзагруженных изображений при создании сущности
- `BuildingService` / `PersonService` — при создании используются `image_ids` если присутствуют (backward-compatible: старый путь через inline `ImageCreateDto` сохранён)
- `ConnectionService` — добавлен недостающий `import NoSuchElementException`

### Фронтенд
- `ImageUploader.tsx` — переработан на `Upload.Dragger`: drag & drop зона, прогресс-бар (20→100%), multi-upload, picture-list с превью, блокировка при достижении лимита
- `BuildingEditPage.tsx` — секция «Фотографии» с `ImageUploader`, загрузка существующих фото в `initialValues`, корректная передача `image_ids` при сохранении (create и edit)
- `PersonEditPage.tsx` — аналогичные изменения

## Поток данных
```
Drag & drop файла
  → POST /api/admin/images → S3 + MongoDB Image doc
  ← { _id, text, url_to_s3 }
«Сохранить» → image_ids: [id1, id2, ...]
  → PATCH/POST /admin/objects|persons
  → Building/Person с @DBRef → Image
```

## Тестирование
1. Открыть форму редактирования объекта или персоны
2. В секции «Фотографии» перетащить изображение или кликнуть для выбора
3. Файл должен загрузиться в S3, появиться в списке с превью
4. Нажать «Сохранить» — сущность должна сохраниться с привязанными изображениями
5. При повторном открытии формы — фото должны загружаться из БД

🤖 Generated with [Claude Code](https://claude.com/claude-code)