### PR TITLE
feat(admin): открепление/переименование/основное фото, источники и авторы в карточках

### DIFF
--- a/backend/src/main/java/com/benua/backend/controller/ImageController.java
+++ b/backend/src/main/java/com/benua/backend/controller/ImageController.java
@@ -41,6 +41,16 @@ public class ImageController {
         return imageService.toDto(saved);
     }
 
+    /** Переименовывает изображение (обновляет поле text). */
+    @PatchMapping("/{id}")
+    public ImageDto rename(@PathVariable String id, @RequestBody java.util.Map<String, String> body) {
+        Image existing = imageRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Image not found: " + id));
+        String newText = body.getOrDefault("text", existing.text());
+        Image updated = new Image(existing._id(), newText, existing.urlToS3(), existing.s3Key());
+        return imageService.toDto(imageRepository.save(updated));
+    }
+
     /** Возвращает свежий presigned URL для существующего изображения. */
     @GetMapping("/{id}/url")
     public ImageDto refreshUrl(@PathVariable String id) {

--- a/backend/src/main/java/com/benua/backend/dto/BuildingCreateDto.java
+++ b/backend/src/main/java/com/benua/backend/dto/BuildingCreateDto.java
@@ -23,6 +23,8 @@ public record BuildingCreateDto(
         @JsonProperty("sources") List<SourceCreateDto> sources,
         @JsonProperty("images") List<ImageCreateDto> images,
         @JsonProperty("image_ids") List<String> imageIds,
+        @JsonProperty("featured_image_id") String featuredImageId,
         @JsonProperty("building_type") String buildingType,
-        @JsonProperty("building_subtype") String buildingSubtype
+        @JsonProperty("building_subtype") String buildingSubtype,
+        @JsonProperty("authors") List<String> authors
 ) {}

--- a/backend/src/main/java/com/benua/backend/dto/BuildingDto.java
+++ b/backend/src/main/java/com/benua/backend/dto/BuildingDto.java
@@ -35,7 +35,9 @@ public record BuildingDto(
         Integer sortOrder,
         Boolean isPublished,
         Instant createdAt,
-        Instant updatedAt
+        Instant updatedAt,
+        String featuredImageId,
+        List<String> authors
 ) {
     /**
      * Минимальный объект для вложенных связей: только _id и name

--- a/backend/src/main/java/com/benua/backend/dto/BuildingUpdateDto.java
+++ b/backend/src/main/java/com/benua/backend/dto/BuildingUpdateDto.java
@@ -24,5 +24,7 @@ public record BuildingUpdateDto(
         @JsonProperty("building_type") String buildingType,
         @JsonProperty("building_subtype") String buildingSubtype,
         @JsonProperty("sort_order") Integer sortOrder,
-        @JsonProperty("is_published") Boolean isPublished
+        @JsonProperty("is_published") Boolean isPublished,
+        @JsonProperty("featured_image_id") String featuredImageId,
+        @JsonProperty("authors") List<String> authors
 ) {}

--- a/backend/src/main/java/com/benua/backend/dto/PersonCreateDto.java
+++ b/backend/src/main/java/com/benua/backend/dto/PersonCreateDto.java
@@ -18,5 +18,7 @@ public record PersonCreateDto(
         @JsonProperty("connected_objects") List<String> connectedObjects,
         @JsonProperty("images") List<ImageCreateDto> images,
         @JsonProperty("image_ids") List<String> imageIds,
-        @JsonProperty("sources") List<SourceCreateDto> sources
+        @JsonProperty("featured_image_id") String featuredImageId,
+        @JsonProperty("sources") List<SourceCreateDto> sources,
+        @JsonProperty("authors") List<String> authors
 ) {}

--- a/backend/src/main/java/com/benua/backend/dto/PersonDto.java
+++ b/backend/src/main/java/com/benua/backend/dto/PersonDto.java
@@ -29,7 +29,9 @@ public record PersonDto(
         Integer sortOrder,
         Boolean isPublished,
         Instant createdAt,
-        Instant updatedAt
+        Instant updatedAt,
+        String featuredImageId,
+        List<String> authors
 ) {
     /**
      * Минимальный объект для вложенных связей: только _id и name

--- a/backend/src/main/java/com/benua/backend/dto/PersonUpdateDto.java
+++ b/backend/src/main/java/com/benua/backend/dto/PersonUpdateDto.java
@@ -18,5 +18,7 @@ public record PersonUpdateDto(
         @JsonProperty("image_ids") List<String> imageIds,
         @JsonProperty("sources") List<SourceCreateDto> sources,
         @JsonProperty("sort_order") Integer sortOrder,
-        @JsonProperty("is_published") Boolean isPublished
+        @JsonProperty("is_published") Boolean isPublished,
+        @JsonProperty("featured_image_id") String featuredImageId,
+        @JsonProperty("authors") List<String> authors
 ) {}

--- a/backend/src/main/java/com/benua/backend/migration/DataMigrationService.java
+++ b/backend/src/main/java/com/benua/backend/migration/DataMigrationService.java
@@ -107,7 +107,8 @@ public class DataMigrationService {
                         List.of(),
                         dto.images() != null ? dto.images() : List.of(),
                         dto.sources() != null ? dto.sources() : List.of(),
-                        null, true, Instant.now(), Instant.now(), null
+                        null, true, Instant.now(), Instant.now(), null,
+                        null, null
                 ));
                 log.info("Saved person (pass 1): {}", dto.id());
             } catch (Exception e) {
@@ -140,7 +141,8 @@ public class DataMigrationService {
                         List.of(),
                         dto.images() != null ? dto.images() : List.of(),
                         dto.sources() != null ? dto.sources() : List.of(),
-                        null, null, null, true, Instant.now(), Instant.now(), null
+                        null, null, null, true, Instant.now(), Instant.now(), null,
+                        null, null
                 ));
                 log.info("Saved building (pass 1): {}", dto.id());
             } catch (Exception e) {
@@ -169,7 +171,8 @@ public class DataMigrationService {
                         dto.connectedObjects() != null ? dto.connectedObjects() : List.of(),
                         existing.images(),
                         existing.sources(),
-                        existing.sortOrder(), existing.isPublished(), existing.createdAt(), Instant.now(), null
+                        existing.sortOrder(), existing.isPublished(), existing.createdAt(), Instant.now(), null,
+                        existing.featuredImageId(), existing.authors()
                 ));
                 log.info("Updated person connections: {}", dto.id());
             } catch (Exception e) {
@@ -203,7 +206,8 @@ public class DataMigrationService {
                         existing.images(),
                         existing.sources(),
                         existing.buildingType(), existing.buildingSubtype(),
-                        existing.sortOrder(), existing.isPublished(), existing.createdAt(), Instant.now(), null
+                        existing.sortOrder(), existing.isPublished(), existing.createdAt(), Instant.now(), null,
+                        existing.featuredImageId(), existing.authors()
                 ));
                 log.info("Updated building connections: {}", dto.id());
             } catch (Exception e) {

--- a/backend/src/main/java/com/benua/backend/model/Building.java
+++ b/backend/src/main/java/com/benua/backend/model/Building.java
@@ -54,5 +54,9 @@ public record Building(
         @Field("is_published") Boolean isPublished,
         @Field("created_at") Instant createdAt,
         @Field("updated_at") Instant updatedAt,
-        @Field("updated_by") String updatedBy
+        @Field("updated_by") String updatedBy,
+        /** ID изображения, которое отображается первым / в превью карточки */
+        @Field("featured_image_id") String featuredImageId,
+        /** Авторы — кто выполнял поиск и отбор информации */
+        @Field("authors") List<String> authors
 ) {}

--- a/backend/src/main/java/com/benua/backend/model/Person.java
+++ b/backend/src/main/java/com/benua/backend/model/Person.java
@@ -46,5 +46,9 @@ public record Person(
         @Field("is_published") Boolean isPublished,
         @Field("created_at") Instant createdAt,
         @Field("updated_at") Instant updatedAt,
-        @Field("updated_by") String updatedBy
+        @Field("updated_by") String updatedBy,
+        /** ID изображения, которое отображается первым / в превью карточки */
+        @Field("featured_image_id") String featuredImageId,
+        /** Авторы — кто выполнял поиск и отбор информации */
+        @Field("authors") List<String> authors
 ) {}

--- a/backend/src/main/java/com/benua/backend/service/BuildingService.java
+++ b/backend/src/main/java/com/benua/backend/service/BuildingService.java
@@ -119,7 +119,9 @@ public class BuildingService {
                 false,
                 Instant.now(),
                 Instant.now(),
-                updatedBy
+                updatedBy,
+                building.featuredImageId(),
+                building.authors()
         );
 
         return toDto(br.save(newBuilding));
@@ -160,7 +162,9 @@ public class BuildingService {
                 patch.isPublished() != null ? patch.isPublished() : existing.isPublished(),
                 existing.createdAt(),
                 Instant.now(),
-                updatedBy
+                updatedBy,
+                patch.featuredImageId() != null ? patch.featuredImageId() : existing.featuredImageId(),
+                patch.authors() != null ? patch.authors() : existing.authors()
         );
 
         return toDto(br.save(updated));
@@ -179,7 +183,8 @@ public class BuildingService {
                 existing.connectionWithBenua(), existing.description(), existing.interestingFacts(),
                 existing.connectedPersons(), existing.connectedObjects(), existing.images(), existing.sources(),
                 existing.buildingType(), existing.buildingSubtype(),
-                existing.sortOrder(), value, existing.createdAt(), Instant.now(), updatedBy
+                existing.sortOrder(), value, existing.createdAt(), Instant.now(), updatedBy,
+                existing.featuredImageId(), existing.authors()
         );
         return toDto(br.save(updated));
     }
@@ -209,7 +214,8 @@ public class BuildingService {
                 b.description(), b.interestingFacts(), persons, objects,
                 imageService.toDtoList(b.images()), b.sources(),
                 b.buildingType(), b.buildingSubtype(),
-                b.sortOrder(), b.isPublished(), b.createdAt(), b.updatedAt()
+                b.sortOrder(), b.isPublished(), b.createdAt(), b.updatedAt(),
+                b.featuredImageId(), b.authors()
         );
     }
 }

--- a/backend/src/main/java/com/benua/backend/service/PersonService.java
+++ b/backend/src/main/java/com/benua/backend/service/PersonService.java
@@ -101,7 +101,8 @@ public class PersonService {
                 null, person.name(), person.lifeYears(), person.birthPlace(), person.profession(),
                 person.connectionWithBenua(), person.description(), person.interestingFacts(),
                 connectedPeople, connectedBuildings, images, sources,
-                null, false, Instant.now(), Instant.now(), updatedBy
+                null, false, Instant.now(), Instant.now(), updatedBy,
+                person.featuredImageId(), person.authors()
         );
 
         return toDto(pr.save(newPerson));
@@ -131,7 +132,9 @@ public class PersonService {
                 connectedPeople, connectedBuildings, images, sources,
                 patch.sortOrder() != null ? patch.sortOrder() : existing.sortOrder(),
                 patch.isPublished() != null ? patch.isPublished() : existing.isPublished(),
-                existing.createdAt(), Instant.now(), updatedBy
+                existing.createdAt(), Instant.now(), updatedBy,
+                patch.featuredImageId() != null ? patch.featuredImageId() : existing.featuredImageId(),
+                patch.authors() != null ? patch.authors() : existing.authors()
         );
 
         return toDto(pr.save(updated));
@@ -149,7 +152,8 @@ public class PersonService {
                 existing.profession(), existing.connectionWithBenua(), existing.description(),
                 existing.interestingFacts(), existing.connectedPersons(), existing.connectedObjects(),
                 existing.images(), existing.sources(),
-                existing.sortOrder(), value, existing.createdAt(), Instant.now(), updatedBy
+                existing.sortOrder(), value, existing.createdAt(), Instant.now(), updatedBy,
+                existing.featuredImageId(), existing.authors()
         );
         return toDto(pr.save(updated));
     }
@@ -177,7 +181,8 @@ public class PersonService {
                 p._id(), p.name(), p.lifeYears(), p.birthPlace(), p.profession(), p.connectionWithBenua(),
                 p.description(), p.interestingFacts(), persons, objects,
                 imageService.toDtoList(p.images()), p.sources(),
-                p.sortOrder(), p.isPublished(), p.createdAt(), p.updatedAt()
+                p.sortOrder(), p.isPublished(), p.createdAt(), p.updatedAt(),
+                p.featuredImageId(), p.authors()
         );
     }
 }

--- a/frontend-admin/src/entities/building/types.ts
+++ b/frontend-admin/src/entities/building/types.ts
@@ -17,12 +17,15 @@ export interface BuildingDto {
   connected_persons?: SimpleEntity[];
   connected_objects?: SimpleEntity[];
   images?: ImageDto[];
+  sources?: { _id: string; text: string; url: string }[];
   building_type?: string;
   building_subtype?: string;
   is_published?: boolean;
   sort_order?: number;
   created_at?: string;
   updated_at?: string;
+  featured_image_id?: string;
+  authors?: string[];
 }
 
 export interface BuildingCreateDto {
@@ -44,6 +47,9 @@ export interface BuildingCreateDto {
   connected_objects?: string[];
   images?: InlineImage[];
   image_ids?: string[];
+  featured_image_id?: string;
+  sources?: { text: string; url: string }[];
+  authors?: string[];
 }
 
 export interface BuildingUpdateDto {
@@ -65,4 +71,7 @@ export interface BuildingUpdateDto {
   image_ids?: string[];
   sort_order?: number;
   is_published?: boolean;
+  featured_image_id?: string;
+  sources?: { text: string; url: string }[];
+  authors?: string[];
 }

--- a/frontend-admin/src/entities/image/api.ts
+++ b/frontend-admin/src/entities/image/api.ts
@@ -8,5 +8,9 @@ export const imageApi = {
     fd.append('text', text);
     return uploadMultipart<ImageDto>('/admin/images', fd);
   },
+  /** Переименовать изображение (обновить поле text). Файл в S3 не трогается. */
+  rename: (id: string, text: string): Promise<ImageDto> =>
+    adminApi.patch<ImageDto>(`/admin/images/${id}`, { text }),
+  /** Удалить изображение из MongoDB и S3 полностью. */
   delete: (id: string): Promise<void> => adminApi.delete(`/admin/images/${id}`),
 };

--- a/frontend-admin/src/entities/person/api.ts
+++ b/frontend-admin/src/entities/person/api.ts
@@ -3,7 +3,7 @@ import type { PersonDto, PersonCreateDto, PersonUpdateDto } from './types';
 
 export const personApi = {
   list: (params?: Record<string, unknown>): Promise<PersonDto[]> =>
-    adminApi.get('/persons', { params: { size: 100, ...params } }),
+    adminApi.get('/persons', { params: { size: 10000, ...params } }),
 
   get: (id: string): Promise<PersonDto> => adminApi.get(`/persons/${id}`),
 

--- a/frontend-admin/src/entities/person/types.ts
+++ b/frontend-admin/src/entities/person/types.ts
@@ -22,10 +22,13 @@ export interface PersonDto {
   connected_persons?: SimpleEntity[];
   connected_objects?: SimpleEntity[];
   images?: ImageDto[];
+  sources?: { _id: string; text: string; url: string }[];
   is_published?: boolean;
   sort_order?: number;
   created_at?: string;
   updated_at?: string;
+  featured_image_id?: string;
+  authors?: string[];
 }
 
 export interface InlineImage {
@@ -45,6 +48,9 @@ export interface PersonCreateDto {
   connected_objects?: string[];
   images?: InlineImage[];
   image_ids?: string[];
+  featured_image_id?: string;
+  sources?: { text: string; url: string }[];
+  authors?: string[];
 }
 
 export interface PersonUpdateDto {
@@ -60,4 +66,7 @@ export interface PersonUpdateDto {
   image_ids?: string[];
   sort_order?: number;
   is_published?: boolean;
+  featured_image_id?: string;
+  sources?: { text: string; url: string }[];
+  authors?: string[];
 }

--- a/frontend-admin/src/features/image-uploader/ImageUploader.tsx
+++ b/frontend-admin/src/features/image-uploader/ImageUploader.tsx
@@ -1,25 +1,203 @@
-import { Upload, Modal, message } from 'antd';
-import { InboxOutlined } from '@ant-design/icons';
-import type { UploadFile, UploadProps } from 'antd';
+/**
+ * ImageUploader — компонент загрузки и управления изображениями.
+ *
+ * Поведение:
+ * - Drag & drop зона для загрузки новых файлов в S3 (POST /admin/images)
+ * - Открепить фото = убрать из списка сущности, файл в S3 НЕ удаляется
+ * - Переименовать = inline-редактирование → PATCH /admin/images/{id}
+ * - Основное фото = звёздочка, сохраняется через featuredImageId / onFeaturedChange
+ */
+
+import { useState } from 'react';
+import { Upload, Input, Space, Tag, Tooltip, Popconfirm, message, Spin } from 'antd';
+import {
+  InboxOutlined,
+  StarFilled,
+  DisconnectOutlined,
+  EditOutlined,
+  CheckOutlined,
+  CloseOutlined,
+} from '@ant-design/icons';
+import type { UploadProps } from 'antd';
 import { imageApi } from 'entities/image/api';
 import type { ImageDto } from 'entities/image/types';
 
 const { Dragger } = Upload;
 
+// ─── пропы ──────────────────────────────────────────────────────────────────
+
 interface Props {
+  /** Текущий список изображений (управляемый через Form.Item) */
   value?: ImageDto[];
   onChange?: (images: ImageDto[]) => void;
+  /** ID основного изображения */
+  featuredImageId?: string | null;
+  onFeaturedChange?: (id: string | null) => void;
+  /** Максимальное количество файлов (undefined = без ограничений) */
   maxCount?: number;
 }
 
-export function ImageUploader({ value = [], onChange, maxCount }: Props) {
-  const fileList: UploadFile[] = value.map((img) => ({
-    uid: img._id,
-    name: img.text || img._id,
-    status: 'done' as const,
-    url: img.url_to_s3,
-    thumbUrl: img.url_to_s3,
-  }));
+// ─── компонент одного изображения ───────────────────────────────────────────
+
+interface ItemProps {
+  image: ImageDto;
+  isFeatured: boolean;
+  onSetFeatured: () => void;
+  onUnlink: () => void;
+  onRenamed: (updated: ImageDto) => void;
+}
+
+function ImageItem({ image, isFeatured, onSetFeatured, onUnlink, onRenamed }: ItemProps) {
+  const [editing, setEditing] = useState(false);
+  const [editText, setEditText] = useState(image.text ?? '');
+  const [renaming, setRenaming] = useState(false);
+
+  const commitRename = async () => {
+    const trimmed = editText.trim();
+    if (!trimmed || trimmed === image.text) {
+      setEditing(false);
+      return;
+    }
+    setRenaming(true);
+    try {
+      const updated = await imageApi.rename(image._id, trimmed);
+      onRenamed(updated);
+      setEditing(false);
+    } catch {
+      message.error('Не удалось переименовать');
+    } finally {
+      setRenaming(false);
+    }
+  };
+
+  const cancelRename = () => {
+    setEditText(image.text ?? '');
+    setEditing(false);
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '8px 10px',
+        marginTop: 8,
+        borderRadius: 6,
+        border: '1px solid',
+        borderColor: isFeatured ? '#faad14' : '#f0f0f0',
+        background: isFeatured ? '#fffbe6' : '#fff',
+        transition: 'all 0.2s',
+      }}
+    >
+      {/* Превью */}
+      <img
+        src={image.url_to_s3}
+        alt={image.text}
+        style={{ width: 56, height: 56, objectFit: 'cover', borderRadius: 4, flexShrink: 0 }}
+      />
+
+      {/* Название */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        {editing ? (
+          <Space.Compact style={{ width: '100%' }}>
+            <Input
+              size="small"
+              value={editText}
+              autoFocus
+              disabled={renaming}
+              onChange={(e) => setEditText(e.target.value)}
+              onPressEnter={commitRename}
+              style={{ flex: 1 }}
+            />
+            <Tooltip title="Сохранить">
+              <Input.Search
+                size="small"
+                enterButton={renaming ? <Spin size="small" /> : <CheckOutlined />}
+                onSearch={commitRename}
+                style={{ width: 36 }}
+              />
+            </Tooltip>
+            <Tooltip title="Отмена">
+              <Input.Search
+                size="small"
+                enterButton={<CloseOutlined />}
+                onSearch={cancelRename}
+                style={{ width: 36 }}
+              />
+            </Tooltip>
+          </Space.Compact>
+        ) : (
+          <Space size={4} wrap>
+            {isFeatured && (
+              <Tag color="gold" icon={<StarFilled />} style={{ margin: 0 }}>
+                Основное
+              </Tag>
+            )}
+            <span
+              style={{
+                maxWidth: 240,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                display: 'inline-block',
+                verticalAlign: 'middle',
+                color: '#333',
+                fontSize: 13,
+              }}
+              title={image.text}
+            >
+              {image.text || '(без названия)'}
+            </span>
+            <Tooltip title="Переименовать">
+              <EditOutlined
+                style={{ color: '#aaa', cursor: 'pointer', fontSize: 13 }}
+                onClick={() => {
+                  setEditText(image.text ?? '');
+                  setEditing(true);
+                }}
+              />
+            </Tooltip>
+          </Space>
+        )}
+      </div>
+
+      {/* Действия */}
+      <Space size={10} style={{ flexShrink: 0 }}>
+        <Tooltip title={isFeatured ? 'Снять как основное' : 'Сделать основным фото'}>
+          <StarFilled
+            style={{ fontSize: 18, color: isFeatured ? '#faad14' : '#d9d9d9', cursor: 'pointer' }}
+            onClick={onSetFeatured}
+          />
+        </Tooltip>
+
+        <Popconfirm
+          title="Открепить фото?"
+          description="Файл останется в хранилище S3."
+          okText="Открепить"
+          okButtonProps={{ danger: true }}
+          cancelText="Отмена"
+          onConfirm={onUnlink}
+        >
+          <Tooltip title="Открепить (файл остаётся в S3)">
+            <DisconnectOutlined style={{ fontSize: 16, color: '#ff4d4f', cursor: 'pointer' }} />
+          </Tooltip>
+        </Popconfirm>
+      </Space>
+    </div>
+  );
+}
+
+// ─── основной компонент ──────────────────────────────────────────────────────
+
+export function ImageUploader({
+  value = [],
+  onChange,
+  featuredImageId,
+  onFeaturedChange,
+  maxCount,
+}: Props) {
+  const atLimit = !!maxCount && value.length >= maxCount;
 
   const handleUpload: UploadProps['customRequest'] = async ({
     file,
@@ -39,51 +217,52 @@ export function ImageUploader({ value = [], onChange, maxCount }: Props) {
     }
   };
 
-  const handleRemove = (file: UploadFile): Promise<boolean> =>
-    new Promise((resolve) => {
-      Modal.confirm({
-        title: 'Удалить фото?',
-        content: 'Файл будет удалён из хранилища. Это действие необратимо.',
-        okText: 'Удалить',
-        okButtonProps: { danger: true },
-        cancelText: 'Отмена',
-        onOk: async () => {
-          try {
-            await imageApi.delete(file.uid);
-            onChange?.(value.filter((img) => img._id !== file.uid));
-            resolve(true);
-          } catch {
-            message.error('Ошибка удаления файла');
-            resolve(false);
-          }
-        },
-        onCancel: () => resolve(false),
-      });
-    });
+  const handleUnlink = (id: string) => {
+    onChange?.(value.filter((img) => img._id !== id));
+    // если открепляем основное — сбрасываем featuredImageId
+    if (featuredImageId === id) onFeaturedChange?.(null);
+  };
 
-  const atLimit = !!maxCount && fileList.length >= maxCount;
+  const handleSetFeatured = (id: string) => {
+    onFeaturedChange?.(featuredImageId === id ? null : id);
+  };
+
+  const handleRenamed = (updated: ImageDto) => {
+    onChange?.(value.map((img) => (img._id === updated._id ? updated : img)));
+  };
 
   return (
-    <Dragger
-      listType="picture"
-      fileList={fileList}
-      customRequest={handleUpload}
-      onRemove={handleRemove}
-      accept="image/jpeg,image/png,image/webp"
-      multiple={!maxCount || maxCount > 1}
-      disabled={atLimit}
-      style={atLimit ? { pointerEvents: 'none', opacity: 0.5 } : undefined}
-    >
-      <p className="ant-upload-drag-icon">
-        <InboxOutlined />
-      </p>
-      <p className="ant-upload-text">
-        Перетащите изображения сюда или нажмите для выбора
-      </p>
-      <p className="ant-upload-hint">
-        JPG, PNG, WebP · не более 10 МБ на файл
-        {maxCount ? ` · максимум ${maxCount} шт.` : ''}
-      </p>
-    </Dragger>
+    <div>
+      {/* Зона загрузки */}
+      {!atLimit && (
+        <Dragger
+          customRequest={handleUpload}
+          accept="image/jpeg,image/png,image/webp"
+          multiple={!maxCount || maxCount > 1}
+          showUploadList={false}
+        >
+          <p className="ant-upload-drag-icon">
+            <InboxOutlined />
+          </p>
+          <p className="ant-upload-text">Перетащите изображения сюда или нажмите для выбора</p>
+          <p className="ant-upload-hint">
+            JPG, PNG, WebP · до 10 МБ на файл
+            {maxCount ? ` · максимум ${maxCount} шт.` : ''}
+          </p>
+        </Dragger>
+      )}
+
+      {/* Список загруженных изображений */}
+      {value.map((img) => (
+        <ImageItem
+          key={img._id}
+          image={img}
+          isFeatured={featuredImageId === img._id}
+          onSetFeatured={() => handleSetFeatured(img._id)}
+          onUnlink={() => handleUnlink(img._id)}
+          onRenamed={handleRenamed}
+        />
+      ))}
+    </div>
   );
 }

--- a/frontend-admin/src/pages/buildings/BuildingEditPage.tsx
+++ b/frontend-admin/src/pages/buildings/BuildingEditPage.tsx
@@ -80,6 +80,7 @@ export function BuildingEditPage({ mode }: Props) {
   const navigate = useNavigate();
   const [form] = Form.useForm();
   const selectedType = Form.useWatch('building_type', form) as string | undefined;
+  const watchedFeaturedId = Form.useWatch('featured_image_id', form) as string | undefined;
 
   const { data: existing, isLoading } = useBuilding(id ?? '');
   const createMutation = useCreateBuilding();
@@ -107,12 +108,25 @@ export function BuildingEditPage({ mode }: Props) {
           connected_persons: existing.connected_persons?.map((p) => p._id) ?? [],
           connected_objects: existing.connected_objects?.map((o) => o._id) ?? [],
           images: existing.images ?? [],
+          featured_image_id: existing.featured_image_id ?? null,
+          sources: existing.sources?.map((s) => ({ text: s.text, url: s.url })) ?? [],
+          authors: existing.authors ?? [],
         }
-      : { is_published: false, description: [], interesting_facts: [], images: [] };
+      : {
+          is_published: false,
+          description: [],
+          interesting_facts: [],
+          images: [],
+          featured_image_id: null,
+          sources: [],
+          authors: [],
+        };
 
   const onFinish = async (values: Record<string, unknown>) => {
     const uploadedImages = (values.images as ImageDto[] | undefined) ?? [];
     const imageIds = uploadedImages.map((img) => img._id);
+    const featuredImageId = (values.featured_image_id as string | null | undefined) ?? null;
+
     try {
       if (mode === 'create') {
         const dto: BuildingCreateDto = {
@@ -131,6 +145,11 @@ export function BuildingEditPage({ mode }: Props) {
           connected_persons: values.connected_persons as string[] | undefined,
           connected_objects: values.connected_objects as string[] | undefined,
           image_ids: imageIds,
+          featured_image_id: featuredImageId ?? undefined,
+          sources: (values.sources as { text?: string; url?: string }[] | undefined)
+            ?.filter((s) => s?.text || s?.url)
+            .map((s) => ({ text: s.text ?? '', url: s.url ?? '' })),
+          authors: (values.authors as string[] | undefined)?.filter(Boolean),
         };
         await createMutation.mutateAsync(dto);
         message.success('Объект создан');
@@ -151,6 +170,11 @@ export function BuildingEditPage({ mode }: Props) {
           connected_persons: values.connected_persons as string[] | undefined,
           connected_objects: values.connected_objects as string[] | undefined,
           image_ids: imageIds,
+          featured_image_id: featuredImageId ?? undefined,
+          sources: (values.sources as { text?: string; url?: string }[] | undefined)
+            ?.filter((s) => s?.text || s?.url)
+            .map((s) => ({ text: s.text ?? '', url: s.url ?? '' })),
+          authors: (values.authors as string[] | undefined)?.filter(Boolean),
         };
         await updateMutation.mutateAsync(dto);
         message.success('Объект обновлён');
@@ -263,10 +287,61 @@ export function BuildingEditPage({ mode }: Props) {
           />
         </Form.Item>
 
+        {/* ── Фотографии ── */}
         <Divider>Фотографии</Divider>
-        <Form.Item name="images">
-          <ImageUploader />
+        {/* Скрытое поле для featured_image_id */}
+        <Form.Item name="featured_image_id" hidden>
+          <Input />
         </Form.Item>
+        <Form.Item name="images">
+          <ImageUploader
+            featuredImageId={watchedFeaturedId}
+            onFeaturedChange={(fid) => form.setFieldValue('featured_image_id', fid)}
+          />
+        </Form.Item>
+
+        {/* ── Источники ── */}
+        <Divider>Источники</Divider>
+        <Form.List name="sources">
+          {(fields, { add, remove }) => (
+            <>
+              {fields.map(({ key, name }) => (
+                <Space key={key} align="baseline" style={{ display: 'flex', marginBottom: 8 }}>
+                  <Form.Item name={[name, 'text']} style={{ marginBottom: 0, width: 340 }}>
+                    <Input placeholder="Название источника" />
+                  </Form.Item>
+                  <Form.Item name={[name, 'url']} style={{ marginBottom: 0, width: 280 }}>
+                    <Input placeholder="https://..." />
+                  </Form.Item>
+                  <MinusCircleOutlined style={{ color: '#ff4d4f' }} onClick={() => remove(name)} />
+                </Space>
+              ))}
+              <Button icon={<PlusOutlined />} onClick={() => add()} size="small">
+                Добавить источник
+              </Button>
+            </>
+          )}
+        </Form.List>
+
+        {/* ── Авторы ── */}
+        <Divider>Авторы (поиск и отбор информации)</Divider>
+        <Form.List name="authors">
+          {(fields, { add, remove }) => (
+            <>
+              {fields.map(({ key, name }) => (
+                <Space key={key} align="baseline" style={{ display: 'flex', marginBottom: 8 }}>
+                  <Form.Item name={name} style={{ flex: 1, marginBottom: 0 }}>
+                    <Input placeholder="Фамилия Имя..." style={{ width: 400 }} />
+                  </Form.Item>
+                  <MinusCircleOutlined style={{ color: '#ff4d4f' }} onClick={() => remove(name)} />
+                </Space>
+              ))}
+              <Button icon={<PlusOutlined />} onClick={() => add()} size="small">
+                Добавить автора
+              </Button>
+            </>
+          )}
+        </Form.List>
 
         <Divider />
         <Form.Item name="is_published" label="Опубликовано" valuePropName="checked">

--- a/frontend-admin/src/pages/buildings/BuildingEditPage.tsx
+++ b/frontend-admin/src/pages/buildings/BuildingEditPage.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Form, Input, Button, Space, Typography, message, Spin, Switch, Divider, Select } from 'antd';
 import { PlusOutlined, MinusCircleOutlined } from '@ant-design/icons';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -80,13 +81,19 @@ export function BuildingEditPage({ mode }: Props) {
   const navigate = useNavigate();
   const [form] = Form.useForm();
   const selectedType = Form.useWatch('building_type', form) as string | undefined;
-  const watchedFeaturedId = Form.useWatch('featured_image_id', form) as string | undefined;
+  const [featuredId, setFeaturedId] = useState<string | null>(null);
 
   const { data: existing, isLoading } = useBuilding(id ?? '');
   const createMutation = useCreateBuilding();
   const updateMutation = useUpdateBuilding(id ?? '');
 
   const isPending = createMutation.isPending || updateMutation.isPending;
+
+  useEffect(() => {
+    if (mode === 'edit' && existing) {
+      setFeaturedId(existing.featured_image_id ?? null);
+    }
+  }, [mode, existing?._id]);
 
   if (mode === 'edit' && isLoading) return <Spin />;
 
@@ -125,7 +132,7 @@ export function BuildingEditPage({ mode }: Props) {
   const onFinish = async (values: Record<string, unknown>) => {
     const uploadedImages = (values.images as ImageDto[] | undefined) ?? [];
     const imageIds = uploadedImages.map((img) => img._id);
-    const featuredImageId = (values.featured_image_id as string | null | undefined) ?? null;
+    const featuredImageId = featuredId;
 
     try {
       if (mode === 'create') {
@@ -289,14 +296,10 @@ export function BuildingEditPage({ mode }: Props) {
 
         {/* ── Фотографии ── */}
         <Divider>Фотографии</Divider>
-        {/* Скрытое поле для featured_image_id */}
-        <Form.Item name="featured_image_id" hidden>
-          <Input />
-        </Form.Item>
         <Form.Item name="images">
           <ImageUploader
-            featuredImageId={watchedFeaturedId}
-            onFeaturedChange={(fid) => form.setFieldValue('featured_image_id', fid)}
+            featuredImageId={featuredId}
+            onFeaturedChange={setFeaturedId}
           />
         </Form.Item>
 

--- a/frontend-admin/src/pages/persons/PersonEditPage.tsx
+++ b/frontend-admin/src/pages/persons/PersonEditPage.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Form, Input, Button, Space, Typography, message, Spin, Switch, Divider } from 'antd';
 import { PlusOutlined, MinusCircleOutlined } from '@ant-design/icons';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -17,13 +18,19 @@ export function PersonEditPage({ mode }: Props) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [form] = Form.useForm();
-  const watchedFeaturedId = Form.useWatch('featured_image_id', form) as string | undefined;
+  const [featuredId, setFeaturedId] = useState<string | null>(null);
 
   const { data: existing, isLoading } = usePerson(id ?? '');
   const createMutation = useCreatePerson();
   const updateMutation = useUpdatePerson(id ?? '');
 
   const isPending = createMutation.isPending || updateMutation.isPending;
+
+  useEffect(() => {
+    if (mode === 'edit' && existing) {
+      setFeaturedId(existing.featured_image_id ?? null);
+    }
+  }, [mode, existing?._id]);
 
   if (mode === 'edit' && isLoading) return <Spin />;
 
@@ -58,7 +65,7 @@ export function PersonEditPage({ mode }: Props) {
   const onFinish = async (values: Record<string, unknown>) => {
     const uploadedImages = (values.images as ImageDto[] | undefined) ?? [];
     const imageIds = uploadedImages.map((img) => img._id);
-    const featuredImageId = (values.featured_image_id as string | null | undefined) ?? null;
+    const featuredImageId = featuredId;
 
     try {
       if (mode === 'create') {
@@ -185,13 +192,10 @@ export function PersonEditPage({ mode }: Props) {
 
         {/* ── Фотографии ── */}
         <Divider>Фотографии</Divider>
-        <Form.Item name="featured_image_id" hidden>
-          <Input />
-        </Form.Item>
         <Form.Item name="images">
           <ImageUploader
-            featuredImageId={watchedFeaturedId}
-            onFeaturedChange={(fid) => form.setFieldValue('featured_image_id', fid)}
+            featuredImageId={featuredId}
+            onFeaturedChange={setFeaturedId}
           />
         </Form.Item>
 

--- a/frontend-admin/src/pages/persons/PersonEditPage.tsx
+++ b/frontend-admin/src/pages/persons/PersonEditPage.tsx
@@ -17,6 +17,7 @@ export function PersonEditPage({ mode }: Props) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [form] = Form.useForm();
+  const watchedFeaturedId = Form.useWatch('featured_image_id', form) as string | undefined;
 
   const { data: existing, isLoading } = usePerson(id ?? '');
   const createMutation = useCreatePerson();
@@ -40,12 +41,25 @@ export function PersonEditPage({ mode }: Props) {
           connected_persons: existing.connected_persons?.map((p) => p._id) ?? [],
           connected_objects: existing.connected_objects?.map((o) => o._id) ?? [],
           images: existing.images ?? [],
+          featured_image_id: existing.featured_image_id ?? null,
+          sources: existing.sources?.map((s) => ({ text: s.text, url: s.url })) ?? [],
+          authors: existing.authors ?? [],
         }
-      : { is_published: false, description: [], interesting_facts: [], images: [] };
+      : {
+          is_published: false,
+          description: [],
+          interesting_facts: [],
+          images: [],
+          featured_image_id: null,
+          sources: [],
+          authors: [],
+        };
 
   const onFinish = async (values: Record<string, unknown>) => {
     const uploadedImages = (values.images as ImageDto[] | undefined) ?? [];
     const imageIds = uploadedImages.map((img) => img._id);
+    const featuredImageId = (values.featured_image_id as string | null | undefined) ?? null;
+
     try {
       if (mode === 'create') {
         const dto: PersonCreateDto = {
@@ -59,6 +73,11 @@ export function PersonEditPage({ mode }: Props) {
           connected_persons: values.connected_persons as string[] | undefined,
           connected_objects: values.connected_objects as string[] | undefined,
           image_ids: imageIds,
+          featured_image_id: featuredImageId ?? undefined,
+          sources: (values.sources as { text?: string; url?: string }[] | undefined)
+            ?.filter((s) => s?.text || s?.url)
+            .map((s) => ({ text: s.text ?? '', url: s.url ?? '' })),
+          authors: (values.authors as string[] | undefined)?.filter(Boolean),
         };
         await createMutation.mutateAsync(dto);
         message.success('Персона создана');
@@ -75,6 +94,11 @@ export function PersonEditPage({ mode }: Props) {
           connected_persons: values.connected_persons as string[] | undefined,
           connected_objects: values.connected_objects as string[] | undefined,
           image_ids: imageIds,
+          featured_image_id: featuredImageId ?? undefined,
+          sources: (values.sources as { text?: string; url?: string }[] | undefined)
+            ?.filter((s) => s?.text || s?.url)
+            .map((s) => ({ text: s.text ?? '', url: s.url ?? '' })),
+          authors: (values.authors as string[] | undefined)?.filter(Boolean),
         };
         await updateMutation.mutateAsync(dto);
         message.success('Персона обновлена');
@@ -159,10 +183,60 @@ export function PersonEditPage({ mode }: Props) {
           )}
         </Form.List>
 
+        {/* ── Фотографии ── */}
         <Divider>Фотографии</Divider>
-        <Form.Item name="images">
-          <ImageUploader />
+        <Form.Item name="featured_image_id" hidden>
+          <Input />
         </Form.Item>
+        <Form.Item name="images">
+          <ImageUploader
+            featuredImageId={watchedFeaturedId}
+            onFeaturedChange={(fid) => form.setFieldValue('featured_image_id', fid)}
+          />
+        </Form.Item>
+
+        {/* ── Источники ── */}
+        <Divider>Источники</Divider>
+        <Form.List name="sources">
+          {(fields, { add, remove }) => (
+            <>
+              {fields.map(({ key, name }) => (
+                <Space key={key} align="baseline" style={{ display: 'flex', marginBottom: 8 }}>
+                  <Form.Item name={[name, 'text']} style={{ marginBottom: 0, width: 340 }}>
+                    <Input placeholder="Название источника" />
+                  </Form.Item>
+                  <Form.Item name={[name, 'url']} style={{ marginBottom: 0, width: 280 }}>
+                    <Input placeholder="https://..." />
+                  </Form.Item>
+                  <MinusCircleOutlined style={{ color: '#ff4d4f' }} onClick={() => remove(name)} />
+                </Space>
+              ))}
+              <Button icon={<PlusOutlined />} onClick={() => add()} size="small">
+                Добавить источник
+              </Button>
+            </>
+          )}
+        </Form.List>
+
+        {/* ── Авторы ── */}
+        <Divider>Авторы (поиск и отбор информации)</Divider>
+        <Form.List name="authors">
+          {(fields, { add, remove }) => (
+            <>
+              {fields.map(({ key, name }) => (
+                <Space key={key} align="baseline" style={{ display: 'flex', marginBottom: 8 }}>
+                  <Form.Item name={name} style={{ flex: 1, marginBottom: 0 }}>
+                    <Input placeholder="Фамилия Имя..." style={{ width: 400 }} />
+                  </Form.Item>
+                  <MinusCircleOutlined style={{ color: '#ff4d4f' }} onClick={() => remove(name)} />
+                </Space>
+              ))}
+              <Button icon={<PlusOutlined />} onClick={() => add()} size="small">
+                Добавить автора
+              </Button>
+            </>
+          )}
+        </Form.List>
 
         <Divider />
         <Form.Item name="is_published" label="Опубликовано" valuePropName="checked">

--- a/frontend/src/entities/object/ui/ObjectCard.jsx
+++ b/frontend/src/entities/object/ui/ObjectCard.jsx
@@ -29,10 +29,15 @@ export function ObjectCard({ object }) {
       tabIndex={0}
     >
       <div className={styles.imageWrapper}>
-        {object.images?.[0]
-          ? <img className={styles.image} src={object.images[0].url_to_s3} alt={object.name} loading="lazy" />
-          : <div className={styles.imagePlaceholder} />
-        }
+        {(() => {
+          const coverImage =
+            (object.featured_image_id &&
+              object.images?.find((img) => img._id === object.featured_image_id)) ||
+            object.images?.[0];
+          return coverImage?.url_to_s3
+            ? <img className={styles.image} src={coverImage.url_to_s3} alt={object.name} loading="lazy" />
+            : <div className={styles.imagePlaceholder} />;
+        })()}
       </div>
       <div className={styles.content}>
         <h3 className={styles.name}>{object.name}</h3>

--- a/frontend/src/entities/person/ui/PersonCard.jsx
+++ b/frontend/src/entities/person/ui/PersonCard.jsx
@@ -27,10 +27,15 @@ export function PersonCard({ person }) {
       tabIndex={0}
     >
       <div className={styles.imageWrapper}>
-        {person.images?.[0]?.url_to_s3
-          ? <img className={styles.image} src={person.images[0].url_to_s3} alt={person.name} loading="lazy" />
-          : <div className={styles.imagePlaceholder} />
-        }
+        {(() => {
+          const coverImage =
+            (person.featured_image_id &&
+              person.images?.find((img) => img._id === person.featured_image_id)) ||
+            person.images?.[0];
+          return coverImage?.url_to_s3
+            ? <img className={styles.image} src={coverImage.url_to_s3} alt={person.name} loading="lazy" />
+            : <div className={styles.imagePlaceholder} />;
+        })()}
       </div>
       <div className={styles.content}>
         <h3 className={styles.name}>{person.name}</h3>

--- a/frontend/src/pages/object-detail/ui/components/ObjectHero/ObjectHero.jsx
+++ b/frontend/src/pages/object-detail/ui/components/ObjectHero/ObjectHero.jsx
@@ -19,7 +19,10 @@ const PersonIcon = () => (
 );
 
 export const ObjectHero = ({ object }) => {
-  const coverImage = object.images?.[0];
+  const coverImage =
+    (object.featured_image_id &&
+      object.images?.find((img) => img._id === object.featured_image_id)) ||
+    object.images?.[0];
 
   return (
     <section className={styles.hero}>

--- a/frontend/src/pages/objects/ui/components/ObjectCatalogCard/ObjectCatalogCard.jsx
+++ b/frontend/src/pages/objects/ui/components/ObjectCatalogCard/ObjectCatalogCard.jsx
@@ -31,7 +31,11 @@ const formatPersons = (persons = []) => {
 export const ObjectCatalogCard = ({ object }) => {
   const navigate = useNavigate();
 
-  const coverUrl = object.images?.[0]?.url_to_s3;
+  const coverImage =
+    (object.featured_image_id &&
+      object.images?.find((img) => img._id === object.featured_image_id)) ||
+    object.images?.[0];
+  const coverUrl = coverImage?.url_to_s3;
   const personsText = formatPersons(object.connected_persons);
 
   return (

--- a/frontend/src/pages/person-detail/ui/components/PersonHero/PersonHero.jsx
+++ b/frontend/src/pages/person-detail/ui/components/PersonHero/PersonHero.jsx
@@ -19,7 +19,10 @@ const PersonIcon = () => (
 );
 
 export const PersonHero = ({ person }) => {
-  const coverImage = person.images?.[0];
+  const coverImage =
+    (person.featured_image_id &&
+      person.images?.find((img) => img._id === person.featured_image_id)) ||
+    person.images?.[0];
 
   return (
     <section className={styles.hero}>


### PR DESCRIPTION
## Что сделано

### Фотографии в формах редактирования

| Действие | Поведение |
|---|---|
| **Открепить** | Убирает фото из карточки, файл в S3 **не удаляется** |
| **Переименовать** | Inline-редактирование → `PATCH /admin/images/{id}` |
| **Основное фото** | Звёздочка → сохраняется как `featured_image_id` |

### Новые поля в карточках
- **Источники** — список «название + URL» (как в экскурсиях)
- **Авторы** — кто выполнял поиск и отбор информации

---

### Backend
- `Building` / `Person`: поля `featured_image_id`, `authors`
- Все Create/Update/Response DTO: новые поля
- `BuildingService` / `PersonService`: сквозная передача новых полей
- `ImageController`: `PATCH /admin/images/{id}` — переименование (S3 не трогается)

### Frontend
- `ImageUploader` — полная переработка: зона drag & drop + кастомный список изображений с inline-переименованием, звёздочкой (основное) и кнопкой открепления (`Popconfirm`)
- `imageApi.rename(id, text)`
- `BuildingEditPage` / `PersonEditPage`: секции Фотографии, Источники, Авторы; featured_image_id через `Form.useWatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)