### PR TITLE
fix(scroll): сброс скролла в начало при переходе между страницами

### DIFF
--- a/frontend/src/app/layouts/MainLayout.jsx
+++ b/frontend/src/app/layouts/MainLayout.jsx
@@ -1,11 +1,13 @@
 import { Outlet } from "react-router-dom";
 import { Header } from "widgets/header";
 import { Footer } from "widgets/footer";
+import { ScrollToTop } from "shared/lib/scroll";
 import styles from "./MainLayout.module.css";
 
 export const MainLayout = () => {
   return (
     <div className={styles.layout}>
+      <ScrollToTop />
       <Header />
       <main className={styles.main}>
         <Outlet />

--- a/frontend/src/shared/lib/scroll/ScrollToTop.jsx
+++ b/frontend/src/shared/lib/scroll/ScrollToTop.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Сбрасывает скролл страницы в начало при каждом переходе между маршрутами.
+ * Размещается внутри роутера, выше <Outlet />.
+ */
+export function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/frontend/src/shared/lib/scroll/index.js
+++ b/frontend/src/shared/lib/scroll/index.js
@@ -1,0 +1,1 @@
+export { ScrollToTop } from './ScrollToTop';


### PR DESCRIPTION
## Проблема
При переходе на новую страницу скролл оставался там, где был на предыдущей.

## Решение
`ScrollToTop` — компонент в `shared/lib/scroll`:
- слушает `useLocation().pathname` через `useEffect`
- при каждом изменении маршрута вызывает `window.scrollTo(0, 0)`
- рендерит `null` — никакой разметки не добавляет

Подключён в `MainLayout` выше `<Outlet />`, поэтому покрывает все страницы приложения.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)