### PR TITLE
feat(buildings): подтипы Инфраструктура/Транспорт + авторы на публичном фронте

### DIFF
--- a/frontend-admin/src/pages/buildings/BuildingEditPage.tsx
+++ b/frontend-admin/src/pages/buildings/BuildingEditPage.tsx
@@ -61,6 +61,8 @@ const BUILDING_CATEGORIES = [
     subcategories: [
       { value: 'factories', label: 'Заводы и фабрики' },
       { value: 'railway', label: 'Железнодорожные объекты' },
+      { value: 'infrastructure', label: 'Инфраструктура' },
+      { value: 'transport', label: 'Транспорт' },
     ],
   },
   {

--- a/frontend/src/pages/object-detail/ui/ObjectDetail.jsx
+++ b/frontend/src/pages/object-detail/ui/ObjectDetail.jsx
@@ -74,6 +74,14 @@ export function ObjectDetail() {
 
       {/* ── 5. Sources ── */}
       <SourcesList sources={object.sources ?? []} />
+
+      {/* ── 6. Authors ── */}
+      {object.authors?.length > 0 && (
+        <div className={styles.authors}>
+          <span className={styles.authorsLabel}>Поиск и отбор информации: </span>
+          {object.authors.join(', ')}
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/src/pages/object-detail/ui/ObjectDetail.module.css
+++ b/frontend/src/pages/object-detail/ui/ObjectDetail.module.css
@@ -41,3 +41,24 @@
         padding: var(--page-padding-y) 1.5rem;
     }
 }
+
+/* ── Authors ── */
+.authors {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 1rem var(--page-padding) 2rem;
+    font-family: var(--font-lora);
+    font-size: 0.82rem;
+    color: var(--black);
+    opacity: 0.7;
+}
+
+.authorsLabel {
+    font-style: italic;
+}
+
+@media (max-width: 768px) {
+    .authors {
+        padding: 1rem 1.5rem 2rem;
+    }
+}


### PR DESCRIPTION
## Summary

- Добавлены два подтипа к типу **Промышленные и транспортные объекты** в форме редактирования объекта в админке: `Инфраструктура` и `Транспорт`
- На публичной странице объекта добавлен вывод **авторов статьи** — данные уже возвращались бэкендом, но фронтенд их не отображал

## Test plan

- [x] В админке открыть/создать объект → тип «Промышленные и транспортные объекты» → убедиться, что в списке подтипов появились «Инфраструктура» и «Транспорт»
- [x] На публичном сайте открыть объект с заполненными авторами → под источниками должна появиться строка «Поиск и отбор информации: …»
- [x] Объект без авторов → блок авторов не отображается

🤖 Generated with [Claude Code](https://claude.com/claude-code)